### PR TITLE
Use typed `EngineStep.Name` for `EngineStepHook` (remove hardcoded step-name strings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,12 @@ Default reset intent code: `RESET_SESSION`.
 @Component
 public class MyHook implements EngineStepHook {
     @Override
-    public boolean supports(String stepName, EngineSession session) {
-        return "SchemaExtractionStep".equals(stepName);
+    public boolean supports(EngineStep.Name stepName, EngineSession session) {
+        return EngineStep.Name.SchemaExtractionStep == stepName;
     }
 
     @Override
-    public void beforeStep(String stepName, EngineSession session) {
+    public void beforeStep(EngineStep.Name stepName, EngineSession session) {
         session.putInputParam("consumer_hint", "compact");
     }
 }

--- a/src/main/java/com/github/salilvnair/convengine/engine/factory/EnginePipelineFactory.java
+++ b/src/main/java/com/github/salilvnair/convengine/engine/factory/EnginePipelineFactory.java
@@ -274,6 +274,7 @@ public class EnginePipelineFactory {
         public StepResult execute(EngineSession session) {
             long start = System.nanoTime();
             String stepName = delegate.getClass().getSimpleName();
+            EngineStep.Name typedStepName = EngineStep.Name.fromStepName(stepName);
             String stepClass = delegate.getClass().getName();
             AuditSessionContext.set(session);
 
@@ -290,8 +291,8 @@ public class EnginePipelineFactory {
             );
             for (EngineStepHook hook : stepHooks) {
                 runHookSafely(() -> {
-                    if (hook.supports(stepName, session)) {
-                        hook.beforeStep(stepName, session);
+                    if (hook.supports(typedStepName, session)) {
+                        hook.beforeStep(typedStepName, session);
                     }
                 }, hook, "beforeStep", stepName, session);
             }
@@ -305,8 +306,8 @@ public class EnginePipelineFactory {
                 session.getStepTimings().add(timing);
                 for (EngineStepHook hook : stepHooks) {
                     runHookSafely(() -> {
-                        if (hook.supports(stepName, session)) {
-                            hook.afterStep(stepName, session, r);
+                        if (hook.supports(typedStepName, session)) {
+                            hook.afterStep(typedStepName, session, r);
                         }
                     }, hook, "afterStep", stepName, session);
                 }
@@ -332,8 +333,8 @@ public class EnginePipelineFactory {
                 session.getStepTimings().add(timing);
                 for (EngineStepHook hook : stepHooks) {
                     runHookSafely(() -> {
-                        if (hook.supports(stepName, session)) {
-                            hook.onStepError(stepName, session, e);
+                        if (hook.supports(typedStepName, session)) {
+                            hook.onStepError(typedStepName, session, e);
                         }
                     }, hook, "onStepError", stepName, session);
                 }

--- a/src/main/java/com/github/salilvnair/convengine/engine/hook/EngineStepHook.java
+++ b/src/main/java/com/github/salilvnair/convengine/engine/hook/EngineStepHook.java
@@ -1,18 +1,35 @@
 package com.github.salilvnair.convengine.engine.hook;
 
+import com.github.salilvnair.convengine.engine.pipeline.EngineStep;
 import com.github.salilvnair.convengine.engine.pipeline.StepResult;
 import com.github.salilvnair.convengine.engine.session.EngineSession;
 
 public interface EngineStepHook {
 
+    default boolean supports(EngineStep.Name stepName, EngineSession session) {
+        return supports(stepName == null ? null : stepName.name(), session);
+    }
+
     default boolean supports(String stepName, EngineSession session) {
         return true;
+    }
+
+    default void beforeStep(EngineStep.Name stepName, EngineSession session) {
+        beforeStep(stepName == null ? null : stepName.name(), session);
     }
 
     default void beforeStep(String stepName, EngineSession session) {
     }
 
+    default void afterStep(EngineStep.Name stepName, EngineSession session, StepResult result) {
+        afterStep(stepName == null ? null : stepName.name(), session, result);
+    }
+
     default void afterStep(String stepName, EngineSession session, StepResult result) {
+    }
+
+    default void onStepError(EngineStep.Name stepName, EngineSession session, Throwable error) {
+        onStepError(stepName == null ? null : stepName.name(), session, error);
     }
 
     default void onStepError(String stepName, EngineSession session, Throwable error) {

--- a/src/main/java/com/github/salilvnair/convengine/engine/pipeline/EngineStep.java
+++ b/src/main/java/com/github/salilvnair/convengine/engine/pipeline/EngineStep.java
@@ -4,4 +4,47 @@ import com.github.salilvnair.convengine.engine.session.EngineSession;
 
 public interface EngineStep {
     StepResult execute(EngineSession session);
+
+    enum Name {
+        AuditUserInputStep,
+        IntentResolutionStep,
+        AddContainerDataStep,
+        SchemaExtractionStep,
+        ResponseResolutionStep,
+        AutoAdvanceStep,
+        McpToolStep,
+        LoadOrCreateConversationStep,
+        FallbackIntentStateStep,
+        PersistConversationBootstrapStep,
+        ResetConversationStep,
+        PersistConversationStep,
+        PipelineEndGuardStep,
+        ResetResolvedIntentStep,
+        PolicyEnforcementStep,
+        RulesStep,
+        Unknown;
+
+        public static Name fromStepName(String stepName) {
+            if (stepName == null || stepName.isBlank()) {
+                return Unknown;
+            }
+            for (Name value : values()) {
+                if (value.name().equalsIgnoreCase(stepName.trim())) {
+                    return value;
+                }
+            }
+            return Unknown;
+        }
+
+        public static Name fromStepClass(Class<?> stepClass) {
+            if (stepClass == null) {
+                return Unknown;
+            }
+            return fromStepName(stepClass.getSimpleName());
+        }
+
+        public boolean matches(String stepName) {
+            return name().equalsIgnoreCase(stepName == null ? "" : stepName.trim());
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces a typed step-name API for hook matching so consumers can avoid hardcoded strings like `"SchemaExtractionStep"`.

## What Changed

### Core (convengine)
- Added `EngineStep.Name` enum in:
  - `src/main/java/com/github/salilvnair/convengine/engine/pipeline/EngineStep.java`
- Added helper methods:
  - `EngineStep.Name.fromStepName(String)`
  - `EngineStep.Name.fromStepClass(Class<?>)`
  - `EngineStep.Name.matches(String)`
- Extended `EngineStepHook` with typed overloads in:
  - `src/main/java/com/github/salilvnair/convengine/engine/hook/EngineStepHook.java`
  - `supports(EngineStep.Name, EngineSession)`
  - `beforeStep(EngineStep.Name, EngineSession)`
  - `afterStep(EngineStep.Name, EngineSession, StepResult)`
  - `onStepError(EngineStep.Name, EngineSession, Throwable)`
- Updated pipeline invocation to call typed hook methods in:
  - `src/main/java/com/github/salilvnair/convengine/engine/factory/EnginePipelineFactory.java`

### Docs (convengine-docs)
- Updated hook usage examples to enum-based matching:
  - `docs/consumer/extensions.mdx`
  - `docs/api/java-api.mdx`
  - `docs/consumer/backend-integration.mdx`

## Backward Compatibility
- Existing string-based hook methods are still supported.
- Typed overloads delegate to existing string methods by default.
- No breaking API removal in this change.

## Consumer Usage (new preferred style)
```java
@Override
public boolean supports(EngineStep.Name stepName, EngineSession session) {
    return EngineStep.Name.SchemaExtractionStep == stepName;
}
